### PR TITLE
Allow strings to be passed to `push` and `replace`

### DIFF
--- a/interfaces/react-router-redux.d.js
+++ b/interfaces/react-router-redux.d.js
@@ -1,10 +1,28 @@
+type Pathname = string;
+type Search = string;
+type Hash = string;
+
+type Query = Object;
+type LocationState = ?Object;
+
+type LocationDescriptorObject = {
+  pathname: Pathname;
+  search: Search;
+  query: Query;
+  state: LocationState;
+};
+
+type Path = Pathname + Search + Hash;
+
+type LocationDescriptor = LocationDescriptorObject | Path;
+
 declare module 'react-router-redux' {
   declare interface ReactRouterRedux {
     go: (number: number) => any;
     goBack: () => any;
     goForward: () => any;
-    push: (location: Object) => any;
-    replace: (location: Object) => any;
+    push: (location: LocationDescriptor) => any;
+    replace: (location: LocationDescriptor) => any;
     syncHistoryWithStore: (history: Object, state: any, options: ?{
       adjustUrlOnReplay?: boolean,
       selectLocationState?: (state: any) => any,


### PR DESCRIPTION
Currently the `push` and `replace` method only allow Objects, while the spec also allows `strings`
Therefore I added the types as specified here: https://github.com/mjackson/history/blob/master/docs/Glossary.md\#locationdescriptor
that not just allow strings now but use a more specified type for the object allowed
